### PR TITLE
[DC-1337]: update rockbench to support update workloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ RockBench can also measure the speed of patches.
 
 Setting `NUM_DOCS` to a non-negative value will limit the number of writes made and then perform patches against that document set.
 Patch mode must be explicitly enabled via `MODE=patch` and the patches per second is controlled via `PPS`.
+`PPS` == `WPS` unless `PPS` is specified.
 `BATCH_SIZE` is used for both patching and inserting.
 Each patch will update a timestamp field for latency detection and also one other field/array in the document.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ docker build -t data_generator .
 docker run -e [env variable as above] data_generator
 ```
 
+### Modes
+RockBench can also measure the speed of patches.
+
+Setting `NUM_DOCS` to a non-negative value will limit the number of writes made and then perform patches against that document set.
+Patch mode must be explicitly enabled via `MODE=patch` and the patches per second is controlled via `PPS`.
+`BATCH_SIZE` is used for both patching and inserting.
+Each patch will update a timestamp field for latency detection and also one other field/array in the document.
+
+Patches can take on various forms, currently
+- replace: replaces random fields with roughly equivalent type and similar size
+- add: Adds new top level fields and prepends entries into the top level tags array
+
+Specify `PATCH_MODE` as either 'replace' or 'add'. Default will be 'replace'.
+
+
 ## How to extend RockBench to measure your favourite realtime database
 
 Implement the [Destination](https://github.com/rockset/rockbench/blob/master/generator/destination.go) interface and provide the appropriate configs required. Check [Rockset](https://github.com/rockset/rockbench/blob/master/generator/rockset.go) and [Elastic](https://github.com/rockset/rockbench/blob/master/generator/elastic.go) for reference. The interface has two methods:

--- a/generator/destination.go
+++ b/generator/destination.go
@@ -14,6 +14,9 @@ type Destination interface {
 	// SendDocument sends a batch of documents to the destination.
 	SendDocument(docs []any) error
 
+	// Send a batch of patches to the destination.
+	SendPatch(docs []any) error
+
 	// GetLatestTimestamp get latest timestamp seen in the destination.
 	GetLatestTimestamp() (time.Time, error)
 
@@ -40,6 +43,14 @@ func recordWritesErrored(count float64) {
 	writesErrored.Add(count)
 }
 
+func recordPatchesCompleted(count float64) {
+	patchesCompleted.Add(count)
+}
+
+func recordPatchesErrored(count float64) {
+	patchesErrored.Add(count)
+}
+
 var (
 	// More info can found here: https://godoc.org/github.com/prometheus/client_golang/prometheus#NewSummary
 	objectiveMap = map[float64]float64{0.5: 0.05, 0.95: 0.005}
@@ -52,6 +63,16 @@ var (
 	writesErrored = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "writes_errored",
 		Help: "The total number of writes errored",
+	})
+
+	patchesCompleted = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "patches_completed",
+		Help: "The total number of patches completed",
+	})
+
+	patchesErrored = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "patches_errored",
+		Help: "The total number of patches errored",
 	})
 
 	e2eLatencies = promauto.NewGauge(prometheus.GaugeOpts{

--- a/generator/elastic.go
+++ b/generator/elastic.go
@@ -21,6 +21,11 @@ type Elastic struct {
 	GeneratorIdentifier string
 }
 
+func (j *Elastic) SendPatch(docs []interface{}) error {
+	//TODO implement me
+	panic("implement me")
+}
+
 // SendDocument sends a batch of documents to Rockset
 func (e *Elastic) SendDocument(docs []any) error {
 	numDocs := len(docs)

--- a/generator/null.go
+++ b/generator/null.go
@@ -6,7 +6,12 @@ import "time"
 type Null struct{}
 
 func (n *Null) SendDocument(docs []any) error {
+
 	recordWritesCompleted(float64(len(docs)))
+	return nil
+}
+
+func (n *Null) SendPatch(docs []interface{}) error {
 	return nil
 }
 

--- a/generator/rockset_test.go
+++ b/generator/rockset_test.go
@@ -46,7 +46,7 @@ func NewRocksetClient(result string) *Rockset {
 
 func TestRockset_GetLatestTimestamp(t *testing.T) {
 	expected := time.Now()
-	r := NewRocksetClient(fmt.Sprintf(`{"results":[{"?UNIX_MICROS": %d}]}`,
+	r := NewRocksetClient(fmt.Sprintf(`{"results":[{"ts": %d}]}`,
 		expected.UnixNano()/1000))
 
 	t0, err := r.GetLatestTimestamp()

--- a/generator/snowflake.go
+++ b/generator/snowflake.go
@@ -36,6 +36,11 @@ type Snowflake struct {
 	DBConnection        *sql.DB
 }
 
+func (r *Snowflake) SendPatch(docs []interface{}) error {
+	//TODO implement me
+	panic("implement me")
+}
+
 // Snowflake has concept of stage & pipe:
 //   Stage is a area where data is written by a client before it is loaded to a snowflake table.
 //   Snowpipe (pipe) is a service which allows for bulk ingestion of data from stage to snowflake tables.


### PR DESCRIPTION
Include update workloads against RS.

Has an initial phase of inserts for a number of documents.
Once the initial inserts are performed against the collection, 2 types of updates can be performed against those documents.
1) Single field replace
2) Add field 

See the JSONPatches in main.go for more clarity. 
