### PR TITLE
[DC-1394] Rockbench updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .idea
-generator/generator
+./rockbench

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Patches can take on various forms, currently
 
 Specify `PATCH_MODE` as either 'replace' or 'add'. Default will be 'replace'.
 
+You can also specify the `_id` scheme for Rockset destination to be either `uuid` or `sequential` (increasing sequential numbers) using `ID_MODE`
 
 ## How to extend RockBench to measure your favourite realtime database
 

--- a/generator/elastic_test.go
+++ b/generator/elastic_test.go
@@ -42,7 +42,7 @@ func TestElastic_GetLatestTimestamp(t *testing.T) {
 func TestElastic_SendDocument(t *testing.T) {
 	r := NewElasticClient("")
 
-	docs, err := GenerateDocs(10, "Elastic", r.GeneratorIdentifier)
+	docs, err := GenerateDocs(10, "Elastic", r.GeneratorIdentifier, "sequential")
 	assert.Nil(t, err)
 	err = r.SendDocument(docs)
 	assert.Nil(t, err)

--- a/generator/rockset_test.go
+++ b/generator/rockset_test.go
@@ -57,7 +57,7 @@ func TestRockset_GetLatestTimestamp(t *testing.T) {
 func TestRockset_SendDocument(t *testing.T) {
 	r := NewRocksetClient("")
 
-	docs, err := GenerateDocs(10, "Rockset", r.GeneratorIdentifier)
+	docs, err := GenerateDocs(10, "Rockset", r.GeneratorIdentifier, "uuid")
 	assert.Nil(t, err)
 	err = r.SendDocument(docs)
 	assert.Nil(t, err)

--- a/main.go
+++ b/main.go
@@ -19,15 +19,19 @@ func main() {
 	wps := mustGetEnvInt("WPS")
 	batchSize := mustGetEnvInt("BATCH_SIZE")
 	destination := mustGetEnvString("DESTINATION")
-	num_docs := getEnvDefaultInt("NUM_DOCS", -1)
+	numDocs := getEnvDefaultInt("NUM_DOCS", -1)
 	mode := getEnvDefault("MODE", "add")
-	patch_mode := getEnvDefault("PATCH_MODE", "replace")
+	idMode := getEnvDefault("ID_MODE", "uuid")
+	patchMode := getEnvDefault("PATCH_MODE", "replace")
 
-	if !(patch_mode == "replace" || patch_mode == "add") {
+	if !(patchMode == "replace" || patchMode == "add") {
 		panic("Invalid patch mode specified, expecting either 'replace' or 'add'")
 	}
 	if !(mode == "add" || mode == "patch") {
 		panic("Invalid mode specified, expecting 'add' or 'patch'")
+	}
+	if !(idMode == "uuid" || idMode == "sequential") {
+		panic("Invalid idMode specified, expecting 'uuid' or 'sequential'")
 	}
 
 	pps := getEnvDefaultInt("PPS", wps)
@@ -114,35 +118,11 @@ func main() {
 
 	go signalHandler(signalChan, doneChan)
 
-	// Periodically read number of docs and log to output
-	go func() {
-		t := time.NewTicker(30 * time.Second)
-		defer t.Stop()
-
-		for {
-			select {
-			case <-doneChan:
-				return
-			case <-t.C:
-				latestTimestamp, err := d.GetLatestTimestamp()
-				now := time.Now()
-				latency := now.Sub(latestTimestamp)
-
-				if err == nil {
-					fmt.Printf("Latency: %s\n", latency)
-					generator.RecordE2ELatency(float64(latency.Microseconds()))
-				} else {
-					log.Printf("failed to get latest timespamp: %v", err)
-				}
-			}
-		}
-	}()
-
 	// Write function
 	t := time.NewTicker(time.Second)
 	defer t.Stop()
 	docs_written := 0
-	for num_docs < 0 || docs_written < num_docs {
+	for numDocs < 0 || docs_written < numDocs {
 		select {
 		// when doneChan is closed, receive immediately returns the zero value
 		case <-doneChan:
@@ -151,7 +131,7 @@ func main() {
 		case <-t.C:
 			for i := 0; i < wps; i++ {
 				// TODO: move doc generation out of this loop into a go routine that pre-generates them
-				docs, err := generator.GenerateDocs(batchSize, destination, generatorIdentifier)
+				docs, err := generator.GenerateDocs(batchSize, destination, generatorIdentifier, idMode)
 				if err != nil {
 					log.Printf("document generation failed: %v", err)
 					os.Exit(1)
@@ -172,8 +152,8 @@ func main() {
 			panic("Patches can only be generated for Rockset at this time")
 		}
 		patchChannel := make(chan map[string]interface{}, 1)
-		log.Printf("Sending patches in '%s' mode", patch_mode)
-		if patch_mode == "replace" {
+		log.Printf("Sending patches in '%s' mode", patchMode)
+		if patchMode == "replace" {
 			go generator.RandomFieldReplace(patchChannel)
 		} else {
 			go generator.RandomFieldAdd(patchChannel)

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ func main() {
 	mode := getEnvDefault("MODE", "add")
 	idMode := getEnvDefault("ID_MODE", "uuid")
 	patchMode := getEnvDefault("PATCH_MODE", "replace")
+	collectMetrics := getEnvDefaultBool("METRICS", false)
 
 	if !(patchMode == "replace" || patchMode == "add") {
 		panic("Invalid patch mode specified, expecting either 'replace' or 'add'")
@@ -109,7 +110,9 @@ func main() {
 		log.Fatal("Unsupported destination. Supported options are Rockset, Elastic & Null")
 	}
 
-	// go metricListener()
+	if (collectMetrics) {
+	   go metricListener()
+    }
 
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, os.Kill, os.Interrupt)
@@ -213,6 +216,20 @@ func getEnvDefaultInt(env string, defaultValue int) int {
 	if err != nil {
 		log.Fatalf("env %s is not integer!", env)
 	}
+	return ret
+}
+
+func getEnvDefaultBool(env string, defaultValue bool) bool {
+	v, found := os.LookupEnv(env)
+	if !found {
+		return defaultValue
+	}
+
+	ret, err := strconv.ParseBool(v)
+	if err != nil {
+		log.Fatalf("env %s is not bool!", env)
+	}
+
 	return ret
 }
 

--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func main() {
 		log.Fatal("Unsupported destination. Supported options are Rockset, Elastic & Null")
 	}
 
-	go metricListener()
+	// go metricListener()
 
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, os.Kill, os.Interrupt)


### PR DESCRIPTION
* Change document structure a bit
* Include ID_MODE to allow `uuid` or `sequential` _id for Rockset
* Option to turn on metrics (off by default) - this is convenient if the tool is not run inside docker and multiple clients compete for metrics port
* change some locals to use `camelCase` instead of `snakeCase`