### PR TITLE
fix sending double the number of patches per batch

### DIFF
--- a/generator/document.go
+++ b/generator/document.go
@@ -256,8 +256,10 @@ func genUniqueInRange(limit int, count int) []int {
 	}
 
 	ids := make([]int, count)
+	i := 0
 	for k, _ := range ids_to_patch {
-		ids = append(ids, k)
+		ids[i] = k
+		i++
 	}
 	return ids
 }


### PR DESCRIPTION
While running this saw that the list was initialized with `0` _id value and the actual _ids were appended to the list instead of substituting.