### PR TITLE
[DC-1779] Optimize Rockbench queries

### DIFF
--- a/generator/document.go
+++ b/generator/document.go
@@ -3,10 +3,11 @@ package generator
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/go-faker/faker/v4"
-	guuid "github.com/google/uuid"
 	"math/rand"
 	"time"
+
+	"github.com/go-faker/faker/v4"
+	guuid "github.com/google/uuid"
 )
 
 type DocStruct struct {
@@ -73,7 +74,7 @@ func GenerateDoc(destination, identifier string, idMode string) (interface{}, er
 		return nil, fmt.Errorf("failed to unmarshal document: %w", err)
 	}
 
-	if destination == "Rockset" {
+	if destination == "rockset" {
 		if idMode == "uuid" {
 			doc["_id"] = guuid.New().String()
 		} else {

--- a/generator/elastic.go
+++ b/generator/elastic.go
@@ -85,7 +85,7 @@ func (e *Elastic) GetLatestTimestamp() (time.Time, error) {
 
 	// The identifier needs to be lowercased because by default, Elastic will index text in lowercase and the term query is case-sensitive
 	// This can be avoided using the match query, but this is slightly slower than the term query
-	jsonBody := fmt.Sprintf("{\"aggs\":{\"max_event_time_for_identifier\":{\"filter\":{\"term\":{\"generator_identifier\":\"%s\"}},\"aggs\":{\"max_event_time\":{\"max\":{\"field\":\"_event_time\"}}}}}}", strings.ToLower(e.GeneratorIdentifier))
+	jsonBody := fmt.Sprintf("{\"query\":{\"term\":{\"generator_identifier\": \"%s\"}},\"aggs\":{\"max_event_time_for_identifier\":{\"max\":{\"field\":\"_event_time\"}}}}", strings.ToLower(e.GeneratorIdentifier))
 	req, err := http.NewRequest(http.MethodPost, searchURL, bytes.NewBufferString(jsonBody))
 	if err != nil {
 		return time.Time{}, fmt.Errorf("failed to create new request: %w", err)
@@ -133,7 +133,6 @@ func (e *Elastic) GetLatestTimestamp() (time.Time, error) {
 	// TODO: check type assertions
 	result = result["aggregations"].(map[string]interface{})
 	result = result["max_event_time_for_identifier"].(map[string]interface{})
-	result = result["max_event_time"].(map[string]interface{})
 	if result["value"] == nil {
 		return time.Time{}, errors.New("malformed result, value is nil")
 	}

--- a/generator/elastic_test.go
+++ b/generator/elastic_test.go
@@ -32,7 +32,7 @@ func NewElasticClient(result string) *Elastic {
 }
 func TestElastic_GetLatestTimestamp(t *testing.T) {
 	expected := time.Now()
-	r := NewElasticClient(fmt.Sprintf(`{"aggregations":{"max_event_time_for_identifier":{"max_event_time":{"value":%d}}}}`,
+	r := NewElasticClient(fmt.Sprintf(`{"aggregations":{"max_event_time_for_identifier":{"value":%d}}}`,
 		expected.UnixNano()/1000))
 
 	t0, err := r.GetLatestTimestamp()

--- a/generator/elastic_test.go
+++ b/generator/elastic_test.go
@@ -3,11 +3,12 @@ package generator
 import (
 	"bytes"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func NewElasticClient(result string) *Elastic {

--- a/generator/rockset.go
+++ b/generator/rockset.go
@@ -88,7 +88,7 @@ func (r *Rockset) GetLatestTimestamp() (time.Time, error) {
 
 	url := fmt.Sprintf("%s/v1/orgs/self/queries", r.APIServer)
 	rcollection := strings.Split(r.CollectionPath, ".") // this is already validated to have two components
-	query := fmt.Sprintf("select _ts as ts from \"%s\".\"%s\" where generator_identifier = '%s' ORDER BY _ts DESC limit 1", rcollection[0], rcollection[1], r.GeneratorIdentifier)
+	query := fmt.Sprintf("select UNIX_MICROS(max(_event_time)) as ts from \"%s\".\"%s\" where generator_identifier = '%s'", rcollection[0], rcollection[1], r.GeneratorIdentifier)
 	body := map[string]interface{}{"sql": map[string]interface{}{"query": query}}
 	jsonBody, err := json.Marshal(body)
 	if err != nil {

--- a/generator/rockset_test.go
+++ b/generator/rockset_test.go
@@ -3,11 +3,12 @@ package generator
 import (
 	"bytes"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const defaultRocksetEndpoint = "https://api.rs2.usw2.rockset.com"

--- a/main.go
+++ b/main.go
@@ -167,23 +167,13 @@ func main() {
 				case <-doneChan:
 					return
 				case <-t.C:
-					latestTimestamp, err := d.GetLatestTimestamp()
-					now := time.Now()
-					latency := now.Sub(latestTimestamp)
-
-					if err == nil {
-						fmt.Printf("Latency: %s\n", latency)
-						generator.RecordE2ELatency(float64(latency.Microseconds()))
-					} else {
-						log.Printf("failed to get latest timestamp: %v", err)
-					}
+					getE2ELatency(d)
 				}
 			}
 		}()
 	}
 
 	// Write function
-
 	docs_written := 0
 	t := time.NewTicker(time.Second)
 	defer t.Stop()
@@ -204,7 +194,7 @@ func main() {
 					}
 					go func(i int) {
 						if err := d.SendDocument(docs); err != nil {
-							log.Printf("failed to send document %d of %d: %v", i, wps, err)
+							log.Printf("failed to send document batch %d of %d (wps): %v", i, wps, err)
 						}
 					}(i)
 					docs_written = docs_written + batchSize
@@ -252,6 +242,19 @@ func main() {
 			}
 
 		}
+	}
+}
+
+func getE2ELatency(d generator.Destination) {
+	latestTimestamp, err := d.GetLatestTimestamp()
+	now := time.Now()
+	latency := now.Sub(latestTimestamp)
+
+	if err == nil {
+		fmt.Printf("Latency: %s\n", latency)
+		generator.RecordE2ELatency(float64(latency.Microseconds()))
+	} else {
+		log.Printf("failed to get latest timestamp: %v", err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 func main() {
 	wps := mustGetEnvInt("WPS")
 	batchSize := mustGetEnvInt("BATCH_SIZE")
-	destination := mustGetEnvString("DESTINATION")
+	destination := strings.ToLower(mustGetEnvString("DESTINATION"))
 	numDocs := getEnvDefaultInt("NUM_DOCS", -1)
 	mode := getEnvDefault("MODE", "add")
 	idMode := getEnvDefault("ID_MODE", "uuid")
@@ -61,7 +61,7 @@ func main() {
 
 	var d generator.Destination
 
-	switch strings.ToLower(destination) {
+	switch destination {
 	case "rockset":
 		apiKey := mustGetEnvString("ROCKSET_API_KEY")
 		apiServer := mustGetEnvString("ROCKSET_API_SERVER")
@@ -193,7 +193,7 @@ func main() {
 			// must explicitly set number of docs so updates are applied evenly across document keys
 			generator.SetMaxDoc(numDocs)
 		}
-		if destination != "Rockset" {
+		if destination != "rockset" {
 			panic("Patches can only be generated for Rockset at this time")
 		}
 		patchChannel := make(chan map[string]interface{}, 1)


### PR DESCRIPTION
This PR adds multiple optimizations and fixes in preparation for the recent blog post:
1. Fixes a bug where if you previously specified the destination with all lowercase, the destination wasn't recognized.
2. Adds randomized sleep and an adjustable polling period in order to spread the load of queries or decrease load
3. Add a PROM_PORT parameter to choose which port prometheus metrics is exposed on. This is a workaround for using docker
4. Optimize queries for calculating e2e latency for Rockset and Elastic. Note this only decreases e2e latency through decreasing query load. Ideally there would be 0 load from queries while benchmarking, but this is the only reproducible way to calculate the latencies.