### PR TITLE
[DC-1780] Add clustering and mixed insert/update mode

### DIFF
--- a/generator/document.go
+++ b/generator/document.go
@@ -21,63 +21,6 @@ type DocumentSpec struct {
 	HotClusterPercentage int
 }
 
-// Multiple string, number/float, boolean, object
-// 2kb size message
-type DocStructDouble struct {
-	Guid       string
-	Balance1    float64 `faker:"amount"`
-	Balance2    float64 `faker:"amount"`
-	Balance3    float64 `faker:"amount"`
-	Balance4    float64 `faker:"amount"`
-	Balance5    float64 `faker:"amount"`
-	Balance6    float64 `faker:"amount"`
-	Balance7    float64 `faker:"amount"`
-	Balance8    float64 `faker:"amount"`
-	Balance9    float64 `faker:"amount"`
-	Balance10    float64 `faker:"amount"`
-	Email1      string `faker:"email"`
-	Email2      string `faker:"email"`
-	Email3      string `faker:"email"`
-	Email4      string `faker:"email"`
-	Email5      string `faker:"email"`
-	Email6      string `faker:"email"`
-	Email7      string `faker:"email"`
-	Email8      string `faker:"email"`
-	Email9      string `faker:"email"`
-	Email10      string `faker:"email"`
-	Phone1      string `faker:"phone_number"`
-	Phone2      string `faker:"phone_number"`
-	Phone3      string `faker:"phone_number"`
-	Phone4      string `faker:"phone_number"`
-	Phone5      string `faker:"phone_number"`
-	Phone6      string `faker:"phone_number"`
-	Phone7      string `faker:"phone_number"`
-	Phone8      string `faker:"phone_number"`
-	Phone9      string `faker:"phone_number"`
-	Phone10      string `faker:"phone_number"`
-	Boolean1   bool
-	Boolean2   bool
-	Boolean3   bool
-	Boolean4   bool
-	Boolean5   bool
-	Boolean6   bool
-	Boolean7   bool
-	Boolean8   bool
-	Boolean9   bool
-	Boolean10   bool
-	Address1    AddressStruct
-	Address2    AddressStruct
-	Address3    AddressStruct
-	Address4    AddressStruct
-	Address5    AddressStruct
-	Name1       NameStruct
-	Name2       NameStruct
-	Name3       NameStruct
-	Name4       NameStruct
-	Name5       NameStruct
-	Tags1       []string `faker:"slice_len=9,len=14"`
-}
-
 type DocStruct struct {
 	Guid       string
 	IsActive   bool
@@ -130,7 +73,7 @@ var doc_id = 0
 var max_doc_id = 0
 
 func GenerateDoc(spec DocumentSpec) (interface{}, error) {
-	docStruct := DocStructDouble{}
+	docStruct := DocStruct{}
 	err := faker.FakeData(&docStruct)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate fake document: %w", err)
@@ -146,7 +89,6 @@ func GenerateDoc(spec DocumentSpec) (interface{}, error) {
 	if spec.Destination == "rockset" {
 		if spec.Mode == "mixed" {
 			// Randomly choose a number to decide whether to generate a doc with an existing doc id
-			// Use random instead of modulo to allow other random decisions like factoring to be uncorrelated
 			if rand.Intn(100) < spec.UpdatePercentage {
 				// Choose random id from one already existing doc id
 				doc["_id"] = formatDocId(rand.Intn(getMaxDoc()))
@@ -167,7 +109,7 @@ func GenerateDoc(spec DocumentSpec) (interface{}, error) {
 	}
 
 	if spec.NumClusters > 0 {
-		doc["Cluster1"] = getClusterKey(spec.NumClusters, spec.HotClusterPercentage)
+		doc["cluster1"] = getClusterKey(spec.NumClusters, spec.HotClusterPercentage)
 	}
 
 	doc["_event_time"] = CurrentTimeMicros()

--- a/generator/document.go
+++ b/generator/document.go
@@ -166,12 +166,24 @@ func GenerateDoc(spec DocumentSpec) (interface{}, error) {
 		}
 	}
 
+	if spec.NumClusters > 0 {
+		doc["Cluster1"] = getClusterKey(spec.NumClusters, spec.HotClusterPercentage)
+	}
+
 	doc["_event_time"] = CurrentTimeMicros()
 	// Set _ts as _event_time is not mutable
 	doc["_ts"] = CurrentTimeMicros()
 	doc["generator_identifier"] = spec.GeneratorIdentifier
 
 	return doc, nil
+}
+
+func getClusterKey(numClusters int, hotClusterPercentage int) string {
+ 	if hotClusterPercentage > 0 && rand.Intn(100) < hotClusterPercentage {
+		return "0@gmail.com"
+	} else {
+		return fmt.Sprintf("%d@gmail.com", rand.Intn(numClusters))
+	}
 }
 
 func getMaxDoc() int {

--- a/generator/document.go
+++ b/generator/document.go
@@ -10,6 +10,63 @@ import (
 	guuid "github.com/google/uuid"
 )
 
+// Multiple string, number/float, boolean, object
+// 2kb size message
+type DocStructDouble struct {
+	Guid       string
+	Balance1    float64 `faker:"amount"`
+	Balance2    float64 `faker:"amount"`
+	Balance3    float64 `faker:"amount"`
+	Balance4    float64 `faker:"amount"`
+	Balance5    float64 `faker:"amount"`
+	Balance6    float64 `faker:"amount"`
+	Balance7    float64 `faker:"amount"`
+	Balance8    float64 `faker:"amount"`
+	Balance9    float64 `faker:"amount"`
+	Balance10    float64 `faker:"amount"`
+	Email1      string `faker:"email"`
+	Email2      string `faker:"email"`
+	Email3      string `faker:"email"`
+	Email4      string `faker:"email"`
+	Email5      string `faker:"email"`
+	Email6      string `faker:"email"`
+	Email7      string `faker:"email"`
+	Email8      string `faker:"email"`
+	Email9      string `faker:"email"`
+	Email10      string `faker:"email"`
+	Phone1      string `faker:"phone_number"`
+	Phone2      string `faker:"phone_number"`
+	Phone3      string `faker:"phone_number"`
+	Phone4      string `faker:"phone_number"`
+	Phone5      string `faker:"phone_number"`
+	Phone6      string `faker:"phone_number"`
+	Phone7      string `faker:"phone_number"`
+	Phone8      string `faker:"phone_number"`
+	Phone9      string `faker:"phone_number"`
+	Phone10      string `faker:"phone_number"`
+	Boolean1   bool
+	Boolean2   bool
+	Boolean3   bool
+	Boolean4   bool
+	Boolean5   bool
+	Boolean6   bool
+	Boolean7   bool
+	Boolean8   bool
+	Boolean9   bool
+	Boolean10   bool
+	Address1    AddressStruct
+	Address2    AddressStruct
+	Address3    AddressStruct
+	Address4    AddressStruct
+	Address5    AddressStruct
+	Name1       NameStruct
+	Name2       NameStruct
+	Name3       NameStruct
+	Name4       NameStruct
+	Name5       NameStruct
+	Tags1       []string `faker:"slice_len=9,len=14"`
+}
+
 type DocStruct struct {
 	Guid       string
 	IsActive   bool
@@ -59,9 +116,10 @@ type FriendDetailsStruct struct {
 }
 
 var doc_id = 0
+var max_doc_id = 0
 
 func GenerateDoc(destination, identifier string, idMode string) (interface{}, error) {
-	docStruct := DocStruct{}
+	docStruct := DocStructDouble{}
 	err := faker.FakeData(&docStruct)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate fake document: %w", err)
@@ -77,8 +135,18 @@ func GenerateDoc(destination, identifier string, idMode string) (interface{}, er
 	if destination == "rockset" {
 		if idMode == "uuid" {
 			doc["_id"] = guuid.New().String()
-		} else {
+		} else if idMode == "sequential"{
 			doc["_id"] = formatDocId(doc_id)
+			doc_id = doc_id + 1
+		} else { // upsert
+			// Insert new document every 10 docs
+			if doc_id % 10 == 0 {
+				doc["_id"] = formatDocId(getMaxDoc())
+				SetMaxDoc(getMaxDoc()+1)
+			} else {
+				// Choose random id from one already existing doc id
+				doc["_id"] = formatDocId(rand.Intn(getMaxDoc()))
+			}
 			doc_id = doc_id + 1
 		}
 	}
@@ -94,11 +162,12 @@ func GenerateDoc(destination, identifier string, idMode string) (interface{}, er
 func getMaxDoc() int {
 	// doc_ids are left padded monotonic integers,
 	//this returns the highest exclusive doc id for purposes of issuing patches.
-	return doc_id
+	return max_doc_id
 }
 
 func SetMaxDoc(maxDocId int) {
-	doc_id = maxDocId
+	// doc_id = maxDocId
+	max_doc_id = maxDocId
 }
 
 func CurrentTimeMicros() int64 {
@@ -262,7 +331,7 @@ func genUniqueInRange(limit int, count int) []int {
 
 	ids := make([]int, count)
 	i := 0
-	for k, _ := range ids_to_patch {
+	for k := range ids_to_patch {
 		ids[i] = k
 		i++
 	}

--- a/generator/document.go
+++ b/generator/document.go
@@ -118,7 +118,7 @@ type FriendDetailsStruct struct {
 var doc_id = 0
 var max_doc_id = 0
 
-func GenerateDoc(destination, identifier string, idMode string) (interface{}, error) {
+func GenerateDoc(destination, identifier string, mode string, idMode string) (interface{}, error) {
 	docStruct := DocStructDouble{}
 	err := faker.FakeData(&docStruct)
 	if err != nil {
@@ -133,12 +133,7 @@ func GenerateDoc(destination, identifier string, idMode string) (interface{}, er
 	}
 
 	if destination == "rockset" {
-		if idMode == "uuid" {
-			doc["_id"] = guuid.New().String()
-		} else if idMode == "sequential"{
-			doc["_id"] = formatDocId(doc_id)
-			doc_id = doc_id + 1
-		} else { // upsert
+		if mode == "mixed" {
 			// Insert new document every 10 docs
 			if doc_id % 10 == 0 {
 				doc["_id"] = formatDocId(getMaxDoc())
@@ -148,6 +143,14 @@ func GenerateDoc(destination, identifier string, idMode string) (interface{}, er
 				doc["_id"] = formatDocId(rand.Intn(getMaxDoc()))
 			}
 			doc_id = doc_id + 1
+		// All other modes
+		} else if idMode == "uuid" {
+			doc["_id"] = guuid.New().String()
+		} else if idMode == "sequential"{
+			doc["_id"] = formatDocId(doc_id)
+			doc_id = doc_id + 1
+		} else {
+			panic(fmt.Sprintf("Unsupported generateDoc case: %s", idMode))
 		}
 	}
 
@@ -175,11 +178,11 @@ func CurrentTimeMicros() int64 {
 	return int64(time.Nanosecond) * t.UnixNano() / int64(time.Microsecond)
 }
 
-func GenerateDocs(batchSize int, destination, identifier string, idMode string) ([]interface{}, error) {
+func GenerateDocs(batchSize int, destination, identifier string, mode string, idMode string) ([]interface{}, error) {
 	var docs = make([]interface{}, batchSize, batchSize)
 
 	for i := 0; i < batchSize; i++ {
-		doc, err := GenerateDoc(destination, identifier, idMode)
+		doc, err := GenerateDoc(destination, identifier, mode, idMode)
 		if err != nil {
 			return nil, err
 		}

--- a/generator/elastic_test.go
+++ b/generator/elastic_test.go
@@ -42,8 +42,18 @@ func TestElastic_GetLatestTimestamp(t *testing.T) {
 
 func TestElastic_SendDocument(t *testing.T) {
 	r := NewElasticClient("")
+	spec := DocumentSpec{
+		Destination:          "elastic",
+		GeneratorIdentifier:  r.GeneratorIdentifier,
+		BatchSize:            10,
+		Mode:                 "add",
+		IdMode:               "sequential",
+		UpdatePercentage:     -1,
+		NumClusters:          -1,
+		HotClusterPercentage: -1,
+	};
 
-	docs, err := GenerateDocs(10, "Elastic", r.GeneratorIdentifier, "add", "sequential")
+	docs, err := GenerateDocs(spec)
 	assert.Nil(t, err)
 	err = r.SendDocument(docs)
 	assert.Nil(t, err)

--- a/generator/elastic_test.go
+++ b/generator/elastic_test.go
@@ -43,7 +43,7 @@ func TestElastic_GetLatestTimestamp(t *testing.T) {
 func TestElastic_SendDocument(t *testing.T) {
 	r := NewElasticClient("")
 
-	docs, err := GenerateDocs(10, "Elastic", r.GeneratorIdentifier, "sequential")
+	docs, err := GenerateDocs(10, "Elastic", r.GeneratorIdentifier, "add", "sequential")
 	assert.Nil(t, err)
 	err = r.SendDocument(docs)
 	assert.Nil(t, err)

--- a/generator/rockset_test.go
+++ b/generator/rockset_test.go
@@ -57,8 +57,18 @@ func TestRockset_GetLatestTimestamp(t *testing.T) {
 
 func TestRockset_SendDocument(t *testing.T) {
 	r := NewRocksetClient("")
+	spec := DocumentSpec{
+		Destination:          "rockset",
+		GeneratorIdentifier:  r.GeneratorIdentifier,
+		BatchSize:            10,
+		Mode:                 "add",
+		IdMode:               "uuid",
+		UpdatePercentage:     -1,
+		NumClusters:          -1,
+		HotClusterPercentage: -1,
+	};
 
-	docs, err := GenerateDocs(10, "rockset", r.GeneratorIdentifier, "add", "uuid")
+	docs, err := GenerateDocs(spec)
 	assert.Nil(t, err)
 	err = r.SendDocument(docs)
 	assert.Nil(t, err)

--- a/generator/rockset_test.go
+++ b/generator/rockset_test.go
@@ -58,7 +58,7 @@ func TestRockset_GetLatestTimestamp(t *testing.T) {
 func TestRockset_SendDocument(t *testing.T) {
 	r := NewRocksetClient("")
 
-	docs, err := GenerateDocs(10, "Rockset", r.GeneratorIdentifier, "uuid")
+	docs, err := GenerateDocs(10, "rockset", r.GeneratorIdentifier, "add", "uuid")
 	assert.Nil(t, err)
 	err = r.SendDocument(docs)
 	assert.Nil(t, err)

--- a/main.go
+++ b/main.go
@@ -73,6 +73,14 @@ func main() {
 		}
 	}
 
+	if hotClusterPercentage > 0 && numClusters < 0 {
+		panic("NUM_CLUSTERS must be specified if HOT_CLUSTER_PERCENTAGE is provided.")
+	}
+
+	if hotClusterPercentage == 0 || hotClusterPercentage > 100 || numClusters == 0 {
+		panic("NUM_CLUSTERS must be a positive number and HOT_CLUSTER_PERCENTAGE must be greater than 0 and less than or equal to 100 if specified.")
+	}
+
 	pps := getEnvDefaultInt("PPS", wps)
 	defaultRoundTripper := http.DefaultTransport
 	defaultTransportPointer, ok := defaultRoundTripper.(*http.Transport)

--- a/main.go
+++ b/main.go
@@ -39,10 +39,10 @@ func main() {
 	if !(patchMode == "replace" || patchMode == "add") {
 		panic("Invalid patch mode specified, expecting either 'replace' or 'add'")
 	}
-	if !(mode == "add" || mode == "patch" || mode == "add_then_patch" || mode == "upsert") {
-		panic("Invalid mode specified, expecting one of 'add', 'patch', 'add_then_patch'")
+	if !(mode == "add" || mode == "patch" || mode == "add_then_patch" || mode == "mixed") {
+		panic("Invalid mode specified, expecting one of 'add', 'patch', 'add_then_patch', 'mixed'")
 	}
-	if !(idMode == "uuid" || idMode == "sequential" || idMode == "upsert") {
+	if !(idMode == "uuid" || idMode == "sequential") {
 		panic("Invalid idMode specified, expecting 'uuid' or 'sequential'")
 	}
 
@@ -52,6 +52,18 @@ func main() {
 
 	if mode == "patch" && numDocs <= 0 {
 		panic("Patch mode requires a positive number of docs to perform patches against. Please specify a number of documents via NUM_DOCS env var.")
+	}
+
+	if mode == "mixed" {
+		if idMode != "sequential" {
+			panic("`mixed` MODE supports ID_MODE `sequential` only")
+		}
+		if updatePercentage < 0 || updatePercentage > 100 {
+			panic("`mixed` MODE requires a positive number between 0 and 100. Please specify the percentage of documents to be updates via UPDATE_PERCENTAGE env var")
+		}
+		if maxDocs <= 0 {
+			panic("`mixed` MODE requires a positive number for MAX_DOCS. This tracks the maximum doc id in the collection and can be used to continue adding document ids sequentially. If no documents exist, specify 1")
+		}
 	}
 
 	pps := getEnvDefaultInt("PPS", wps)
@@ -178,12 +190,8 @@ func main() {
 	docs_written := 0
 	t := time.NewTicker(time.Second)
 	defer t.Stop()
-	if mode == "add_then_patch" || mode == "add" || mode == "upsert"{
-		if mode == "upsert" {
-			// must explicitly set number of docs so updates are applied evenly across document keys
-			if maxDocs <= 0 {
-				panic("Upsert mode requires a positive number of existing docs to perform updates against. Please specify a number of documents via MAX_DOCS env var.")
-			}
+	if mode == "add_then_patch" || mode == "add" || mode == "mixed"{
+		if mode == "mixed" {
 			generator.SetMaxDoc(maxDocs)
 		}
 		for numDocs < 0 || docs_written < numDocs {
@@ -195,7 +203,7 @@ func main() {
 			case <-t.C:
 				for i := 0; i < wps; i++ {
 					// TODO: move doc generation out of this loop into a go routine that pre-generates them
-					docs, err := generator.GenerateDocs(batchSize, destination, generatorIdentifier, idMode)
+					docs, err := generator.GenerateDocs(batchSize, destination, generatorIdentifier, mode, idMode)
 					if err != nil {
 						log.Printf("document generation failed: %v", err)
 						os.Exit(1)


### PR DESCRIPTION
This PR adds the following functionality:
- Specify number of distinct cluster values to test clustered collections via `NUM_CLUSTERS`
- Specify percentage of documents hitting a specific cluster to simulate hot clustering via `HOT_CLUSTER_PERCENTAGE`
- Add a mode that mixes inserts and updates randomly via `mixed` mode, `UPDATE_PERCENTAGE`, and `MAX_DOCS`

Mixed mode only works well if there's one kubernetes replica doing the work. The max doc id, n, is tracked locally so that any docs with doc id 0 to n will be updates and n+1 will be an insert. The alternative that would work for multiple replicas is to use a uuid on inserts and for updates choose from 0 to n. This means the collection would need to be populated with docs from 0 to n first, and any newly inserted docs with uuids would never be updated.