### PR TITLE
[DC-2021] Add update workload support for Elastic

### DIFF
--- a/generator/document.go
+++ b/generator/document.go
@@ -86,26 +86,24 @@ func GenerateDoc(spec DocumentSpec) (interface{}, error) {
 		return nil, fmt.Errorf("failed to unmarshal document: %w", err)
 	}
 
-	if spec.Destination == "rockset" {
-		if spec.Mode == "mixed" {
-			// Randomly choose a number to decide whether to generate a doc with an existing doc id
-			if rand.Intn(100) < spec.UpdatePercentage {
-				// Choose random id from one already existing doc id
-				doc["_id"] = formatDocId(rand.Intn(getMaxDoc()))
-			} else {
-				doc["_id"] = formatDocId(getMaxDoc())
-				SetMaxDoc(getMaxDoc()+1)
-			}
-			doc_id = doc_id + 1
-		// All other modes
-		} else if spec.IdMode == "uuid" {
-			doc["_id"] = guuid.New().String()
-		} else if spec.IdMode == "sequential"{
-			doc["_id"] = formatDocId(doc_id)
-			doc_id = doc_id + 1
+	if spec.Mode == "mixed" {
+		// Randomly choose a number to decide whether to generate a doc with an existing doc id
+		if rand.Intn(100) < spec.UpdatePercentage {
+			// Choose random id from one already existing doc id
+			doc["_id"] = formatDocId(rand.Intn(getMaxDoc()))
 		} else {
-			panic(fmt.Sprintf("Unsupported generateDoc case: %s", spec.IdMode))
+			doc["_id"] = formatDocId(getMaxDoc())
+			SetMaxDoc(getMaxDoc()+1)
 		}
+		doc_id = doc_id + 1
+		// All other modes
+	} else if spec.IdMode == "uuid" {
+		doc["_id"] = guuid.New().String()
+	} else if spec.IdMode == "sequential" {
+		doc["_id"] = formatDocId(doc_id)
+		doc_id = doc_id + 1
+	} else {
+		panic(fmt.Sprintf("Unsupported generateDoc case: %s", spec.IdMode))
 	}
 
 	if spec.NumClusters > 0 {
@@ -168,46 +166,71 @@ func RandomString(n int) string {
 	return string(s)
 }
 
-func GeneratePatches(num_patch int, c chan map[string]interface{}) ([]interface{}, error) {
-	ids_to_patch := genUniqueInRange(getMaxDoc(), num_patch)
+func GeneratePatches(num_patch int, destination string, c chan map[string]interface{}) ([]interface{}, error) {
 	patches := make([]interface{}, 0)
 
+	ids_to_patch := genUniqueInRange(getMaxDoc(), num_patch)
 	for _, id := range ids_to_patch {
-		patch := generatePatch(id, <-c)
-		patches = append(patches, patch)
-	}
+		if (destination == "elastic") {
+			patch := generateElasticPatch(id, <-c)
+			patches = append(patches, patch)
 
+		} else if (destination == "rockset") {
+			patch := generateRocksetPatch(id, <-c)
+			patches = append(patches, patch)
+		}
+	}
 	return patches, nil
 }
 
-func RandomFieldAdd(c chan map[string]interface{}) {
+func RandomFieldAdd(destination string, c chan map[string]interface{}) {
 	// Adding fields or array members
 	for {
-		options := []map[string]interface{}{{
-			"op":    "add",
-			"path":  "/" + faker.UUIDDigit(),
-			"value": faker.Email(),
-		},
-			{
+		if (destination == "rockset") {
+			options := []map[string]interface{}{{
+				"op":    "add",
+				"path":  "/" + faker.UUIDDigit(),
+				"value": faker.Email(),
+				},
+				{
 				"op":    "add",
 				"path":  "/Tags/-",
 				"value": faker.UUIDHyphenated(), // Append to tags array
-			},
+				},
+			}
+			shuffleAndFillChannel(options, c)
+		} else if (destination == "elastic") {
+			options := []map[string]interface{}{{
+					"doc": map[string]interface{}{
+						faker.UUIDDigit(): faker.Email(),
+						"_ts": CurrentTimeMicros(),
+					},
+				},
+				{
+					"script": map[string]interface{}{
+						"source": "ctx._source.Tags.add(params.tag)",
+						"params": map[string]interface{}{
+							"tag": faker.UUIDHyphenated(),
+							"_ts": CurrentTimeMicros(),
+						},
+					},
+				},
+			}
+			shuffleAndFillChannel(options, c)
 		}
-		shuffleAndFillChannel(options, c)
 	}
-
 }
 
-func RandomFieldReplace(c chan map[string]interface{}) {
+func RandomFieldReplace(destination string, c chan map[string]interface{}) {
 	// Purely replacement of fields
 	random := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for {
-		options := []map[string]interface{}{{
-			"op":    "replace",
-			"path":  "/Email",
-			"value": faker.Email(),
-		},
+		if (destination == "rockset") {
+			options := []map[string]interface{}{{
+				"op":    "replace",
+				"path":  "/Email",
+				"value": faker.Email(),
+			},
 			{
 				"op":    "replace",
 				"path":  "/About",
@@ -283,7 +306,124 @@ func RandomFieldReplace(c chan map[string]interface{}) {
 				"path":  "/Address/City",
 				"value": faker.Word(),
 			}}
-		shuffleAndFillChannel(options, c)
+			shuffleAndFillChannel(options, c)
+		} else if (destination == "elastic") {
+			options := []map[string]interface{}{{
+				"doc": map[string]interface{}{
+					"Email": faker.Email(),
+					"_ts": CurrentTimeMicros(),
+				},
+			},
+			{
+				"doc": map[string]interface{}{
+					"About": faker.Sentence(),
+					"_ts": CurrentTimeMicros(),
+				},
+			},
+			{
+				"doc": map[string]interface{}{
+					"Company": faker.Word() + "-" + faker.Word(),
+					"_ts": CurrentTimeMicros(),
+				},
+			},
+			{
+				"script": map[string]interface{}{
+					"source": "ctx._source.Name.First = params.updated_nested_first_name; ctx._source._ts = params.ts",
+					"params" : map[string]interface{}{
+						"updated_nested_first_name" : faker.FirstName(),
+						"ts": CurrentTimeMicros(),
+					},
+				},
+			},
+			{
+				"script": map[string]interface{}{
+					"source": "ctx._source.Name.Last = params.updated_nested_last_name; ctx._source._ts = params.ts",
+					"params" : map[string]interface{}{
+						"updated_nested_last_name": faker.LastName(),
+						"ts": CurrentTimeMicros(),
+					},
+				},
+			},
+			{
+				"doc": map[string]interface{}{
+					"Age": random.Intn(100),
+					"_ts": CurrentTimeMicros(),
+				},
+			},
+			{
+				"doc": map[string]interface{}{
+					"Balance": random.Float64(),
+					"_ts": CurrentTimeMicros(),
+				},
+			},
+			{
+				"doc": map[string]interface{}{
+					"Registered": faker.Timestamp(),
+					"_ts": CurrentTimeMicros(),
+				},
+			},
+			{
+				"doc": map[string]interface{}{
+					"Phone": faker.Phonenumber(),
+					"_ts": CurrentTimeMicros(),
+				},
+			},
+			{
+				"doc": map[string]interface{}{
+					"Picture": faker.UUIDDigit(),
+					"_ts": CurrentTimeMicros(),
+				},
+			},
+			{
+				"doc": map[string]interface{}{
+					"Guid": faker.UUIDHyphenated(),
+					"_ts": CurrentTimeMicros(),
+				},
+			},
+			{
+				"doc": map[string]interface{}{
+					"Greeting": faker.Paragraph(),
+					"_ts": CurrentTimeMicros(),
+				},
+			},
+			{
+				"script": map[string]interface{}{
+					"source": "ctx._source.Address.ZipCode = params.updated_nested_zcode; ctx._source._ts = params.ts",
+					"params" : map[string]interface{}{
+						"updated_nested_zcode": random.Intn(100000),
+						"ts": CurrentTimeMicros(),
+					},
+				},
+			},
+			{
+				"script": map[string]interface{}{
+					"source": "ctx._source.Address.Coordinates.Longitude = params.updated_nested_coord_long; ctx._source._ts = params.ts",
+					"params" : map[string]interface{}{
+						"updated_nested_coord_long": faker.Longitude(),
+						"ts": CurrentTimeMicros(),
+					},
+				},
+			},
+			{
+				"script": map[string]interface{}{
+					"source": "ctx._source.Address.Coordinates.Latitude = params.updated_nested_coord_lat; ctx._source._ts = params.ts",
+					"params" : map[string]interface{}{
+						"updated_nested_coord_lat": faker.Latitude(),
+						"ts": CurrentTimeMicros(),
+					},
+				},
+			},
+			{
+				"script": map[string]interface{}{
+					"source": "ctx._source.Address.City = params.updated_nested_city; ctx._source._ts = params.ts",
+					"params" : map[string]interface{}{
+						"updated_nested_city": faker.Word(),
+						"ts": CurrentTimeMicros(),
+					},
+				},
+			}}
+			shuffleAndFillChannel(options, c)
+		}
 	}
 }
 
@@ -307,11 +447,18 @@ func genUniqueInRange(limit int, count int) []int {
 	return ids
 }
 
-func generatePatch(id int, field_patch map[string]interface{}) map[string]interface{} {
+func generateRocksetPatch(id int, field_patch map[string]interface{}) map[string]interface{} {
 	patch := make(map[string]interface{})
 	patch["_id"] = formatDocId(id)
 	add_op := []map[string]interface{}{field_patch, {"op": "add", "path": "/_ts", "value": CurrentTimeMicros()}}
 	patch["patch"] = add_op
+	return patch
+}
+
+func generateElasticPatch(id int, field_patch map[string]interface{}) map[string]interface{} {
+	patch := make(map[string]interface{})
+	patch["_id"] = formatDocId(id)
+	patch["patch"] = field_patch
 	return patch
 }
 

--- a/generator/elastic.go
+++ b/generator/elastic.go
@@ -73,7 +73,6 @@ func (e *Elastic) SendPatch(docs []interface{}) error {
 		}
 		return fmt.Errorf("error code: %d, body: %s", resp.StatusCode, string(bodyBytes))
 	}
-	// fmt.Println("doc sent!")
 	recordPatchesCompleted(float64(numDocs))
 	return nil
 

--- a/main.go
+++ b/main.go
@@ -251,15 +251,15 @@ func main() {
 			// must explicitly set number of docs so updates are applied evenly across document keys
 			generator.SetMaxDoc(numDocs)
 		}
-		if destination != "rockset" {
-			panic("Patches can only be generated for Rockset at this time")
+		if destination != "rockset" && destination != "elastic" {
+			panic("Patches can only be generated for Rockset or elastic at this time")
 		}
 		patchChannel := make(chan map[string]interface{}, 1)
 		log.Printf("Sending patches in '%s' mode", patchMode)
 		if patchMode == "replace" {
-			go generator.RandomFieldReplace(patchChannel)
+			go generator.RandomFieldReplace(destination, patchChannel)
 		} else {
-			go generator.RandomFieldAdd(patchChannel)
+			go generator.RandomFieldAdd(destination, patchChannel)
 		}
 		for {
 			select {
@@ -269,7 +269,7 @@ func main() {
 				os.Exit(0)
 			case <-t.C:
 				for i := 0; i < pps; i++ {
-					docs, err := generator.GeneratePatches(batchSize, patchChannel)
+					docs, err := generator.GeneratePatches(batchSize, destination, patchChannel)
 					if err != nil {
 						log.Printf("patch generation failed: %v", err)
 						os.Exit(1)


### PR DESCRIPTION
Adds support for updating existing or adding new fields to a document in ElasticSearch. This can be used for to benchmark updates. Verified running against Elastic cluster